### PR TITLE
persist filters and fix pagination issues

### DIFF
--- a/cinematch-frontend/src/components/FiltersSidebar.jsx
+++ b/cinematch-frontend/src/components/FiltersSidebar.jsx
@@ -1,4 +1,4 @@
-import { useState} from "react";
+import {useEffect, useState} from "react";
 import "../styles/slider.css";
 import "../styles/year.css";
 import { motion } from "framer-motion";
@@ -12,7 +12,10 @@ export default function FiltersSidebar({ filters, mode, onApply, onClose }) {
     // Local sidebar state (independent)
     const [localFilters, setLocalFilters] = useState(filters);
 
-
+    // Checks if localfilters match the latest state when remounted
+    useEffect(() => {
+        setLocalFilters(filters);
+    }, [filters]);
 
     const genresMovie = [
         "Action", "Adventure", "Animation", "Comedy", "Crime", "Documentary",


### PR DESCRIPTION
Found and fixed below issues:
- Commit filter changes to parent state to make them persistent
- Allow series tab to change pages after filtering movies
- Ensure movies are paginated correctly when filtered
- Maintain active filters when switching pages
- Maintain active filters when viewing movie details and then going back