### PR TITLE
Fixed auto version and added git action to count stats 

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -22,27 +22,21 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            // 1. --- ΑΝΑΛΥΣΗ ΜΗΝΥΜΑΤΟΣ ---
-            const fullMessage = context.payload.head_commit.message; // π.χ. "minor: Create sss"
-            const lowerMessage = fullMessage.toLowerCase();
-            console.log(`Commit: "${fullMessage}"`);
+            const fullMessage = context.payload.head_commit.message;
+            const lines = fullMessage.split('\n');
+            const firstLine = lines[0].trim();
+            const lowerFirstLine = firstLine.toLowerCase();
 
             let bumpType = null;
-            if (lowerMessage.includes('major:')) bumpType = 'major';
-            else if (lowerMessage.includes('minor:')) bumpType = 'minor';
-            else if (lowerMessage.includes('patch:')) bumpType = 'patch';
+            if (lowerFirstLine.includes('major:')) bumpType = 'major';
+            else if (lowerFirstLine.includes('minor:')) bumpType = 'minor';
+            else if (lowerFirstLine.includes('patch:')) bumpType = 'patch';
 
-            if (!bumpType) {
-              console.log('Skipping: No keyword found.');
-              return;
-            }
+            if (!bumpType) return;
 
-            // 2. --- ΚΑΘΑΡΙΣΜΟΣ ΚΕΙΜΕΝΟΥ (Fix για το "minor: sss") ---
-            // Αφαιρούμε το πρόθεμα (minor: κλπ) για να έχουμε καθαρό τίτλο
-            let cleanTitle = fullMessage.replace(/^(major|minor|patch):\s*/i, '').trim();
+            let cleanTitle = firstLine.replace(/^(major|minor|patch):\s*/i, '').trim();
             cleanTitle = cleanTitle.charAt(0).toUpperCase() + cleanTitle.slice(1);
             
-            // 3. --- ΒΡΙΣΚΟΥΜΕ ΤΑ TAGS ---
             let lastTag = 'v0.0.0';
             try {
               let output = '';
@@ -50,9 +44,8 @@ jobs:
                 listeners: { stdout: (data) => { output += data.toString(); } }
               });
               lastTag = output.trim();
-            } catch (e) { console.log("No tags found."); }
+            } catch (e) {}
 
-            // 4. --- ΥΠΟΛΟΓΙΣΜΟΣ ΝΕΟΥ VERSION ---
             let parts = lastTag.replace('v', '').split('.').map(num => parseInt(num, 10));
             if (parts.length < 3 || parts.some(isNaN)) parts = [0, 0, 0];
             let [major, minor, patch] = parts;
@@ -62,9 +55,7 @@ jobs:
             else if (bumpType === 'patch') { patch++; }
 
             const newVersion = `v${major}.${minor}.${patch}`;
-            console.log(`New Version: ${newVersion}`);
 
-            // 5. --- ΔΗΜΙΟΥΡΓΙΑ ΤΟΥ ΝΕΟΥ TAG ---
             try {
               await github.rest.git.createRef({
                 owner: context.repo.owner,
@@ -74,50 +65,24 @@ jobs:
               });
             } catch (e) { return; }
 
-            // 6. --- ΔΗΜΙΟΥΡΓΙΑ RELEASE (ΜΟΝΟ ΓΙΑ MAJOR/MINOR) ---
             if (bumpType === 'major' || bumpType === 'minor') {
-              
-              // Βρίσκουμε το προηγούμενο .0 tag (BASE TAG)
-              let baseTag = '';
-              try {
-                let baseOutput = '';
-                await exec.exec('git', ['describe', '--tags', '--abbrev=0', '--match', 'v*.*.0'], {
-                    listeners: { stdout: (data) => { baseOutput += data.toString(); } },
-                    ignoreReturnCode: true 
-                });
-                baseTag = baseOutput.trim();
-              } catch (e) {}
-              
-              if (!baseTag) baseTag = lastTag; // Fallback
-              
-              
               let autoNotes = "";
               try {
                 const response = await github.rest.repos.generateReleaseNotes({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   tag_name: newVersion,
-                  previous_tag_name: baseTag 
+                  previous_tag_name: lastTag 
                 });
                 autoNotes = response.data.body;
-              } catch (e) { console.log("Auto notes failed"); }
-
-             
-              autoNotes = autoNotes.replace(/minor:\s/gi, ""); 
-
-              // --- ΧΤΙΣΙΜΟ ΤΟΥ ΤΕΛΙΚΟΥ ΚΕΙΜΕΝΟΥ ---
-              // Πρώτη γραμμή: Ο καθαρός τίτλος (χωρίς minor:)
-              let finalBody = `## 🚀 ${cleanTitle}\n\n`;
-              
-              // Ενσωματώνουμε τα generated notes 
-              finalBody += autoNotes;
+              } catch (e) {}
 
               await github.rest.repos.createRelease({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 tag_name: newVersion,
                 name: `${newVersion} - ${cleanTitle}`,
-                body: finalBody,
+                body: `## 🚀 ${cleanTitle}\n\n` + autoNotes,
                 generate_release_notes: false 
               });
             }

--- a/.github/workflows/generate-stats.yml
+++ b/.github/workflows/generate-stats.yml
@@ -1,0 +1,54 @@
+name: Repository Stats Bot
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update-stats:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate STATS.md
+        run: |
+          # 1. Define patterns
+          AUTO_PATTERNS="node_modules|package-lock.json|yarn.lock|dist|build|vendor|manifest.json|weights"
+
+          # 2. Create a temporary folder to hold the file before moving it to the other branch
+          mkdir -p stats-out
+          
+          echo "# Repository Statistics" > stats-out/STATS.md
+          echo "Last updated: $(date -u)" >> stats-out/STATS.md
+          echo "" >> stats-out/STATS.md
+          
+          echo "## 📊 Lines Added per Contributor" >> stats-out/STATS.md
+          echo "| Author | Manual (+) | Auto/Pkg (+) | Total Added |" >> stats-out/STATS.md
+          echo "| :--- | :--- | :--- | :--- |" >> stats-out/STATS.md
+
+          git log --format='%aN' | sort -u | while read author; do
+            manual_added=$(git log --author="$author" --numstat --pretty=tformat: --no-merges | grep -vE "$AUTO_PATTERNS" | awk '{ add += $1 } END { if (add == "") add=0; printf "%s", add }')
+            auto_added=$(git log --author="$author" --numstat --pretty=tformat: --no-merges | grep -E "$AUTO_PATTERNS" | awk '{ add += $1 } END { if (add == "") add=0; printf "%s", add }')
+
+            m_add=${manual_added:-0}; a_add=${auto_added:-0}
+            total=$((m_add + a_add))
+            
+            if [ "$total" != "0" ]; then
+              echo "| $author | $m_add | $a_add | $total |" >> stats-out/STATS.md
+            fi
+          done
+
+      - name: Deploy to Stats Branch
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: stats-out     # The folder containing our new STATS.md
+          branch: stats         # The branch where the file will live
+          commit-message: "docs: update repository statistics"


### PR DESCRIPTION
- fixed a problem on auto version GitHub action:

> when i put minor: for release in commit title, the title of the release should had been the title of the commit without minor, but it was taking the description of the commit too

- Added generate-stats.yml action to count how many lines the code has and how many the contributors have

> it counts how many lines does the contributor has done manually and the auto/packages that are auto added 

> then it pushes it to new branch "stats" as STATS.md. if it the branch doesn't exist it creates it