### PR TITLE
Add unit tests for PersonService TMDB integration and error handling

### DIFF
--- a/src/test/java/com/example/CineMatch/service/PersonServiceEdgeCaseTest.java
+++ b/src/test/java/com/example/CineMatch/service/PersonServiceEdgeCaseTest.java
@@ -1,0 +1,110 @@
+package com.example.CineMatch.service;
+
+import com.example.CineMatch.Repository.TmdbRepository;
+import com.example.CineMatch.dto.PersonDetailsDto;
+import com.example.CineMatch.dto.PersonDto;
+import com.example.CineMatch.dto.ResponseDto;
+import tools.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PersonServiceEdgeCaseTest {
+
+    @Mock
+    TmdbRepository tmdbRepository;
+
+    @Spy
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    @InjectMocks
+    PersonServiceImpl personService;
+
+    @Test
+    void methods_shouldPropagateException_whenRepositoryFails() {
+        when(tmdbRepository.call(anyString()))
+                .thenThrow(new RuntimeException("TMDB down"));
+        when(tmdbRepository.callMap(anyString()))
+                .thenThrow(new RuntimeException("TMDB down"));
+
+        assertThrows(RuntimeException.class, () -> personService.getTrending(1));
+        assertThrows(RuntimeException.class, () -> personService.getSearch("Query", 1));
+        assertThrows(RuntimeException.class, () -> personService.getDetails(1));
+    }
+
+    @Test
+    void methods_shouldThrowException_whenJsonIsInvalid() throws Exception {
+        when(tmdbRepository.call(anyString()))
+                .thenReturn("Invalid JSON");
+
+        Map<String, Object> invalidMap = new HashMap<>();
+        invalidMap.put("invalid", "data");
+
+        when(tmdbRepository.callMap(anyString()))
+                .thenReturn(invalidMap);
+
+        assertThrows(RuntimeException.class, () -> personService.getTrending(1));
+        assertThrows(RuntimeException.class, () -> personService.getSearch("Query", 1));
+        assertThrows(RuntimeException.class, () -> personService.getDetails(1));
+    }
+
+    @Test
+    void getMethods_shouldReturnNullResults_whenNoResultsField() throws Exception {
+        when(tmdbRepository.call(anyString())).thenReturn("{}");
+
+        ResponseDto<PersonDto> trending = personService.getTrending(1);
+        ResponseDto<PersonDto> search = personService.getSearch("Query", 1);
+
+        assertNotNull(trending);
+        assertNotNull(search);
+        assertNull(trending.getResults());
+        assertNull(search.getResults());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 0})
+    void getMethods_shouldHandleInvalidPages(int page) throws Exception {
+        when(tmdbRepository.call(anyString()))
+                .thenThrow(new IllegalArgumentException("Invalid page"));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> personService.getTrending(page));
+        assertThrows(IllegalArgumentException.class,
+                () -> personService.getSearch("Query", page));
+    }
+
+    @Test
+    void getDetails_shouldHandleMissingCastGracefully() throws Exception {
+        long id = 1L;
+
+        Map<String, Object> details = Map.of(
+                "id", 5L,
+                "name", "Bob"
+        );
+
+        Map<String, Object> credits = new HashMap<>();
+        credits.put("cast", null); // Map.of() cannot be used here
+
+        when(tmdbRepository.callMap("/person/" + id)).thenReturn(details);
+        when(tmdbRepository.callMap("/person/" + id + "/movie_credits"))
+                .thenReturn(credits);
+
+        PersonDetailsDto result = personService.getDetails(id);
+
+        assertNotNull(result);
+        assertNull(result.getMovieCredits());
+    }
+}

--- a/src/test/java/com/example/CineMatch/service/PersonServiceHappyPathTest.java
+++ b/src/test/java/com/example/CineMatch/service/PersonServiceHappyPathTest.java
@@ -1,0 +1,119 @@
+package com.example.CineMatch.service;
+
+import com.example.CineMatch.Repository.TmdbRepository;
+import com.example.CineMatch.dto.*;
+import tools.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PersonServiceHappyPathTest {
+
+    @Mock
+    TmdbRepository tmdbRepository;
+
+    @Spy
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    @InjectMocks
+    PersonServiceImpl personService;
+
+    @Test
+    void getTrending_shouldReturnMappedPersons() throws Exception {
+        String json = """
+            {
+              "results": [
+                {
+                  "id": 123,
+                  "name": "Bob",
+                  "known_for_department": "Acting",
+                  "profile_path": "Links"
+                }
+              ]
+            }
+            """;
+
+        when(tmdbRepository.call("/trending/person/week?page=1")).thenReturn(json);
+
+        ResponseDto<PersonDto> response = personService.getTrending(1);
+
+        assertNotNull(response);
+        assertEquals(1, response.getResults().size());
+
+        PersonDto person = response.getResults().getFirst();
+        assertEquals(123, person.getId());
+        assertEquals("Bob", person.getName());
+        assertEquals("Acting", person.getKnownForDepartment());
+        assertEquals("Links", person.getProfilePath());
+    }
+
+    @Test
+    void getSearch_shouldReturnMappedPersons() throws Exception {
+        String json = """
+            {
+              "results": [
+                {
+                  "id": 123,
+                  "name": "Bobby",
+                  "known_for_department": "Acting",
+                  "profile_path": "Links"
+                }
+              ]
+            }
+            """;
+
+        when(tmdbRepository.call("/search/person?query=Bob&page=1"))
+                .thenReturn(json);
+
+        ResponseDto<PersonDto> response = personService.getSearch("Bob", 1);
+
+        assertNotNull(response);
+        assertEquals(1, response.getResults().size());
+
+        PersonDto person = response.getResults().getFirst();
+        assertEquals("Bobby", person.getName());
+    }
+
+    @Test
+    void getDetails_shouldReturnPersonWithMovieCredits() throws Exception {
+        long personId = 125L;
+
+        Map<String, Object> personDetails = Map.of(
+                "id", 125L,
+                "name", "Bob",
+                "known_for_department", "Acting",
+                "birthday", "1999-12-19",
+                "profile_path", "/profile.jpg",
+                "popularity", 9.0
+        );
+
+        Map<String, Object> movieCredits = Map.of(
+                "cast", List.of(
+                        Map.of("id", 3L, "title", "The Rise of Bob")
+                )
+        );
+
+        when(tmdbRepository.callMap("/person/" + personId))
+                .thenReturn(personDetails);
+        when(tmdbRepository.callMap("/person/" + personId + "/movie_credits"))
+                .thenReturn(movieCredits);
+
+        PersonDetailsDto result = personService.getDetails(personId);
+
+        assertNotNull(result);
+        assertEquals(125L, result.getId());
+        assertEquals("Bob", result.getName());
+        assertEquals(1, result.getMovieCredits().size());
+        assertEquals("The Rise of Bob", result.getMovieCredits().getFirst().getTitle());
+    }
+}


### PR DESCRIPTION
The tests verify:
- Trending and search endpoints return correctly mapped Person DTOs
- Person details are assembled properly, including movie credits
- Exceptions from the repository layer are propagated as expected
- Invalid JSON responses are handled safely
- Edge cases such as missing results, invalid page values, and absent cast data do not break the service
